### PR TITLE
Updated the GitHub Actions PreBuild validator so that the executable …

### DIFF
--- a/.github/workflows/prebuild-validator.yml
+++ b/.github/workflows/prebuild-validator.yml
@@ -24,7 +24,7 @@ jobs:
         run: dotnet restore
 
       - name: 🔨 Build validator
-        run: dotnet build Tools/SOLTEC.Core.PreBuildValidator
+        run: dotnet build Tools/SOLTEC.Core.PreBuildValidator --configuration Release
 
       - name: 🚦 Run validator
-        run: dotnet Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll
+        run: dotnet Tools/SOLTEC.Core.PreBuildValidator/bin/Release/net8.0/SOLTEC.Core.PreBuildValidator.dll

--- a/SOLTEC.Core.sln
+++ b/SOLTEC.Core.sln
@@ -25,6 +25,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SOLTEC.Core.PreBuildValidat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SOLTEC.Core.WikiDocGen", "Tools\SOLTEC.Core.WikiDocGen\SOLTEC.Core.WikiDocGen.csproj", "{85032D75-BF0B-4A0C-BF45-88EC598611EB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{544A3704-8645-41CF-91CD-B2636A7FEE1D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{BC0AA913-73B6-4B43-BD43-251EAC8FEB98}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\prebuild-validator.yml = .github\workflows\prebuild-validator.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +67,7 @@ Global
 		{C6B30726-2D87-4F0E-87E5-37662B037935} = {0F9F2555-B997-4547-8C25-5A7CB6BA58A3}
 		{D05D87A0-91AB-4237-BD8C-74C529CDB51E} = {A16F71B6-0F54-4734-B6BD-6E0CCD578E08}
 		{85032D75-BF0B-4A0C-BF45-88EC598611EB} = {A16F71B6-0F54-4734-B6BD-6E0CCD578E08}
+		{BC0AA913-73B6-4B43-BD43-251EAC8FEB98} = {544A3704-8645-41CF-91CD-B2636A7FEE1D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {11301603-2537-4BFA-804D-A81E7F3C767A}

--- a/SOLTEC.Core/SOLTEC.Core.csproj
+++ b/SOLTEC.Core/SOLTEC.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <Target Name="RunPreBuildValidator" BeforeTargets="BeforeBuild">
+	<Target Name="RunPreBuildValidator" BeforeTargets="BeforeBuild" Condition=" '$(GITHUB_ACTIONS)' != 'true' ">
 	<Exec Command="dotnet $(SolutionDir)Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll" />
   </Target>
 


### PR DESCRIPTION
…is no longer searched for in bin/Debug/net8.0/ in GitHub Actions. Because GitHub Actions is compiled with dotnet build, it is therefore generated in Release mode by default unless otherwise specified.

Therefore, we needed to specify --configuration Debug in the build command, or better yet, we should always use Release.