### PR TITLE
The Spanish file, INTEGRATION_ES.md, has been created to learn how to…

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -33,8 +33,8 @@ dotnet Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuild
 Add this to your main `.csproj` (e.g., `SOLTEC.Core.csproj`):
 
 ```xml
-<Target Name="RunPreBuildValidator" BeforeTargets="BeforeBuild">
-  <Exec Command="dotnet Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll" />
+<Target Name="RunPreBuildValidator" BeforeTargets="BeforeBuild" Condition=" '$(GITHUB_ACTIONS)' != 'true' ">
+  <Exec Command="dotnet $(SolutionDir)Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll" />
 </Target>
 ```
 

--- a/INTEGRATION_ES.md
+++ b/INTEGRATION_ES.md
@@ -1,0 +1,89 @@
+# SOLTEC.Core
+
+## SOLTEC.Core.PreBuildValidator
+
+Herramienta de consola para la validación previa a la compilación de los proyectos SOLTEC.Core. Compatible con Visual Studio 2022, JetBrains Rider y GitHub Actions.
+
+---
+
+### ✅ ¿Qué valida?
+
+1. Todos los archivos `.csproj` deben tener:
+   - `LangVersion = 12.0`
+   - `Nullable = enable`
+
+2. Todas las **clases públicas** deben tener documentación XML (`///`)
+3. No deben existir comentarios `TODO` o `FIXME` pendientes
+4. Debe existir al menos un método `[Fact]` o `[Test]` en los proyectos de prueba
+5. (Opcional) El proyecto compila correctamente (este paso está deshabilitado por rendimiento)
+
+---
+
+### ⚙️ Uso manual
+
+```bash
+dotnet build Tools/SOLTEC.Core.PreBuildValidator
+dotnet Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll
+```
+
+---
+
+### 🧪 Integración con Visual Studio
+
+Agrega esto a tu archivo principal `.csproj` (por ejemplo: `SOLTEC.Core.csproj`):
+
+```xml
+<Target Name="RunPreBuildValidator" BeforeTargets="BeforeBuild" Condition=" '$(GITHUB_ACTIONS)' != 'true' ">
+  <Exec Command="dotnet $(SolutionDir)Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll" />
+</Target>
+```
+
+---
+
+### 🧩 Integración con JetBrains Rider
+
+1. Ve a **File > Settings > Build, Execution, Deployment > Build Tools > Before Build**
+2. Agrega una nueva herramienta externa:
+   - **Nombre**: `Run PreBuild Validator`
+   - **Programa**: `dotnet`
+   - **Argumentos**: `Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll`
+   - **Directorio de trabajo**: `$ProjectFileDir$`
+
+---
+
+### 🚀 Integración con GitHub Actions
+
+Agrega este archivo como `.github/workflows/validator.yml`:
+
+```yaml
+name: PreBuild Validator
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  validate-project:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Build Validator
+      run: dotnet build Tools/SOLTEC.Core.PreBuildValidator
+
+    - name: Run Validator
+      run: dotnet Tools/SOLTEC.Core.PreBuildValidator/bin/Debug/net8.0/SOLTEC.Core.PreBuildValidator.dll
+```
+
+---
+
+¡Utiliza esto para evitar que configuraciones incorrectas lleguen a tu rama principal!

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The output will be located in `DOCS/en/` and `DOCS/es/`.
 
 ## 📥 Contributing & Guidelines
 
+- [Integration Guide](INTEGRATION.md)
 - [Contributing Guide](CONTRIBUTING.md)
 - [Security Policy](SECURITY.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/README_ES.md
+++ b/README_ES.md
@@ -139,6 +139,7 @@ La salida se encuentra en `DOCS/en/` y `DOCS/es/`.
 
 ## 📥 Contribuciones y Normas
 
+- [Guía de Integración](INTEGRATION_ES.md)
 - [Guía de Contribución](CONTRIBUTING_ES.md)
 - [Política de Seguridad](SECURITY_ES.md)
 - [Código de Conducta](CODE_OF_CONDUCT_ES.md)


### PR DESCRIPTION
… integrate the SOLTEC.Core project.

A link to the corresponding language file has been created in the README, within the "Contributions and Standards" section, for the INTEGRATION files.

Modified the INTEGRATION file so that the example on how to implement Pre-Build validation takes into account skipping the validator execution in the project from GitHub; this, if not present, caused an endless loop in GitHub Actions, resulting in triggered errors.

"Closes #1 "