### PR TITLE
Fixes with 3 Commits

### DIFF
--- a/SOLTEC.Core/Adapters/Excel/Book.cs
+++ b/SOLTEC.Core/Adapters/Excel/Book.cs
@@ -11,12 +11,12 @@ using System.Text;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// var book = new Book();
-/// var result = book.Open("path\to\file.xlsx");
-/// if (result.IsSuccess)
+/// var _book = new Book();
+/// var _result = _book.Open("path\to\file.xlsx");
+/// if (_result.IsSuccess)
 /// {
-///     int sheets = book.GetSheetCount();
-///     string cell = book.ReadCell(0, "A", 1);
+///     int _sheets = _book.GetSheetCount();
+///     string _cell = _book.ReadCell(0, "A", 1);
 /// }
 /// ]]>
 /// </example>
@@ -27,9 +27,9 @@ using System.Text;
 /// <param name="readerFactory">The reader factory to use for creating Excel readers.</param>
 /// <example>
 /// <![CDATA[
-/// var fileOpener = new DefaultFileOpener();
-/// var readerFactory = new ExcelReaderFactoryWrapper();
-/// var book = new Book(fileOpener, readerFactory);
+/// var _fileOpener = new DefaultFileOpener();
+/// var _readerFactory = new ExcelReaderFactoryWrapper();
+/// var _book = new Book(_fileOpener, _readerFactory);
 /// ]]>
 /// </example>
 public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFactory)
@@ -40,7 +40,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// </summary>
     /// <example>
     /// <![CDATA[
-    /// var book = new Book();
+    /// var _book = new Book();
     /// ]]>
     /// </example>
     public Book() : this(new DefaultFileOpener(), new ExcelReaderFactoryWrapper())
@@ -52,7 +52,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// </summary>
     /// <example>
     /// <![CDATA[
-    /// book.FilePath = "C:\files\myfile.xlsx";
+    /// _book.FilePath = "C:\files\myfile.xlsx";
     /// ]]>
     /// </example>
     public string FilePath { get; set; } = string.Empty;
@@ -61,7 +61,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// </summary>
     /// <example>
     /// <![CDATA[
-    /// DataSet ds = book.Data;
+    /// DataSet _ds = _book.Data;
     /// ]]>
     /// </example>
     public virtual DataSet Data { get; private set; } = new DataSet();
@@ -73,8 +73,8 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>A service response indicating success or error.</returns>
     /// <example>
     /// <![CDATA[
-    /// var book = new Book();
-    /// var result = book.Open("document.xlsx");
+    /// var _book = new Book();
+    /// var _result = _book.Open("document.xlsx");
     /// ]]>
     /// </example>
     public virtual ServiceResponse Open(string filePath)
@@ -82,8 +82,8 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
         FilePath = filePath;
         try
         {
-            using var stream = fileOpener.Open(FilePath);
-            return Open(stream);
+            using var _stream = fileOpener.Open(FilePath);
+            return Open(_stream);
         }
         catch (Exception ex)
         {
@@ -98,17 +98,17 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>A service response indicating success or error.</returns>
     /// <example>
     /// <![CDATA[
-    /// using var stream = File.OpenRead("document.xlsx");
-    /// var book = new Book();
-    /// var result = book.Open(stream);
+    /// using var _stream = File.OpenRead("document.xlsx");
+    /// var _book = new Book();
+    /// var _result = _book.Open(_stream);
     /// ]]>
     /// </example>
     public virtual ServiceResponse Open(Stream stream)
     {
         try
         {
-            using var reader = readerFactory.CreateReader(stream, new ExcelReaderConfiguration { FallbackEncoding = Encoding.GetEncoding(1252) });
-            Data = reader.AsDataSet();
+            using var _reader = readerFactory.CreateReader(stream, new ExcelReaderConfiguration { FallbackEncoding = Encoding.GetEncoding(1252) });
+            Data = _reader.AsDataSet();
             if (Data == null || Data.Tables.Count == 0)
                 return ServiceResponse.CreateError(5, "Invalid or empty Excel file.");
             return ServiceResponse.CreateSuccess(HttpStatusCode.OK);
@@ -125,7 +125,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The number of worksheets.</returns>
     /// <example>
     /// <![CDATA[
-    /// int sheetCount = book.GetSheetCount();
+    /// int _sheetCount = _book.GetSheetCount();
     /// ]]>
     /// </example>
     public int GetSheetCount() => Data?.Tables.Count ?? 0;
@@ -136,7 +136,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The number of rows in the worksheet.</returns>
     /// <example>
     /// <![CDATA[
-    /// int rows = book.GetRowCount(0);
+    /// int _rows = _book.GetRowCount(0);
     /// ]]>
     /// </example>
     public int GetRowCount(int sheetIndex) => Data.Tables[sheetIndex].Rows.Count;
@@ -147,7 +147,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The number of columns in the worksheet.</returns>
     /// <example>
     /// <![CDATA[
-    /// int columns = book.GetColumnCount(0);
+    /// int _columns = _book.GetColumnCount(0);
     /// ]]>
     /// </example>
     public int GetColumnCount(int sheetIndex) => Data.Tables[sheetIndex].Columns.Count;
@@ -158,7 +158,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The name of the worksheet.</returns>
     /// <example>
     /// <![CDATA[
-    /// string name = book.GetSheetName(0);
+    /// string _name = _book.GetSheetName(0);
     /// ]]>
     /// </example>
     public string GetSheetName(int sheetIndex) => Data.Tables[sheetIndex].TableName;
@@ -171,13 +171,13 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The decimal value of the cell, or 0 if parsing fails.</returns>
     /// <example>
     /// <![CDATA[
-    /// decimal value = book.ReadDecimalCell(0, "A", 1);
+    /// decimal _value = _book.ReadDecimalCell(0, "A", 1);
     /// ]]>
     /// </example>
     public decimal ReadDecimalCell(int sheetIndex, string columnLetter, int rowIndex)
     {
-        var value = ReadCell(sheetIndex, columnLetter, rowIndex);
-        return decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
+        var _value = ReadCell(sheetIndex, columnLetter, rowIndex);
+        return decimal.TryParse(_value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
             ? result
             : 0m;
     }
@@ -190,13 +190,13 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The float value of the cell, or 0 if parsing fails.</returns>
     /// <example>
     /// <![CDATA[
-    /// float value = book.ReadFloatCell(0, "B", 1);
+    /// float _value = _book.ReadFloatCell(0, "B", 1);
     /// ]]>
     /// </example>
     public float ReadFloatCell(int sheetIndex, string columnLetter, int rowIndex)
     {
-        var value = ReadCell(sheetIndex, columnLetter, rowIndex);
-        return float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
+        var _value = ReadCell(sheetIndex, columnLetter, rowIndex);
+        return float.TryParse(_value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
             ? result
             : 0f;
     }
@@ -209,13 +209,13 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The int value of the cell, or 0 if parsing fails.</returns>
     /// <example>
     /// <![CDATA[
-    /// int value = book.ReadInt32Cell(0, "D", 1);
+    /// int _value = _book.ReadInt32Cell(0, "D", 1);
     /// ]]>
     /// </example>
     public int ReadInt32Cell(int sheetIndex, string columnLetter, int rowIndex)
     {
-        var value = ReadCell(sheetIndex, columnLetter, rowIndex);
-        return int.TryParse(value, out var result)
+        var _value = ReadCell(sheetIndex, columnLetter, rowIndex);
+        return int.TryParse(_value, out var result)
             ? result
             : 0;
     }
@@ -228,13 +228,13 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The long value of the cell, or 0 if parsing fails.</returns>
     /// <example>
     /// <![CDATA[
-    /// long value = book.ReadInt64Cell(0, "E", 1);
+    /// long _value = _book.ReadInt64Cell(0, "E", 1);
     /// ]]>
     /// </example>
     public long ReadInt64Cell(int sheetIndex, string columnLetter, int rowIndex)
     {
-        var value = ReadCell(sheetIndex, columnLetter, rowIndex);
-        return long.TryParse(value, out var result)
+        var _value = ReadCell(sheetIndex, columnLetter, rowIndex);
+        return long.TryParse(_value, out var result)
             ? result
             : 0L;
     }
@@ -247,13 +247,13 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>The DateTime value of the cell, or DateTime.MinValue if parsing fails.</returns>
     /// <example>
     /// <![CDATA[
-    /// DateTime date = book.ReadDateCell(0, "F", 1);
+    /// DateTime _date = _book.ReadDateCell(0, "F", 1);
     /// ]]>
     /// </example>
     public DateTime ReadDateCell(int sheetIndex, string columnLetter, int rowIndex)
     {
-        var value = ReadCell(sheetIndex, columnLetter, rowIndex);
-        return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
+        var _value = ReadCell(sheetIndex, columnLetter, rowIndex);
+        return DateTime.TryParse(_value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
             ? result
             : DateTime.MinValue;
     }
@@ -266,7 +266,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>String value or empty string.</returns>
     /// <example>
     /// <![CDATA[
-    /// string value = book.ReadCell(0, "G", 7);
+    /// string _value = _book.ReadCell(0, "G", 7);
     /// ]]>
     /// </example>
     public string ReadCell(int sheetIndex, string columnLetter, int row)
@@ -290,7 +290,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>String value or empty string.</returns>
     /// <example>
     /// <![CDATA[
-    /// string value = book.ReadCell(0, 8, 7);
+    /// string _value = _book.ReadCell(0, 8, 7);
     /// ]]>
     /// </example>
     public string ReadCell(int sheetIndex, int columnIndex, int row)
@@ -312,7 +312,7 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
     /// <returns>Zero-based column index.</returns>
     /// <example>
     /// <![CDATA[
-    /// int index = Book.ColumnToIndex("C"); // returns 2
+    /// int _index = _book.ColumnToIndex("C"); // returns 2
     /// ]]>
     /// </example>
     private static int ColumnToIndex(string column)
@@ -321,9 +321,9 @@ public class Book(IFileOpener fileOpener, IExcelReaderFactoryWrapper readerFacto
         var _base = Encoding.ASCII.GetBytes("Z")[0] - Encoding.ASCII.GetBytes("A")[0] + 1;
         var _result = 0;
 
-        for (var i = 0; i < _bytes.Length; i++)
+        for (var _positioni = 0; _positioni < _bytes.Length; _positioni++)
         {
-            var _value = _bytes[i] - Encoding.ASCII.GetBytes("A")[0] + 1;
+            var _value = _bytes[_positioni] - Encoding.ASCII.GetBytes("A")[0] + 1;
             _result = _result * _base + _value;
         }
 

--- a/SOLTEC.Core/Adapters/Excel/Book.cs
+++ b/SOLTEC.Core/Adapters/Excel/Book.cs
@@ -1,10 +1,10 @@
-﻿using ExcelDataReader;
+﻿namespace SOLTEC.Core.Adapters.Excel;
+
+using ExcelDataReader;
 using System.Data;
 using System.Globalization;
 using System.Net;
 using System.Text;
-
-namespace SOLTEC.Core.Adapters.Excel;
 
 /// <summary>
 /// Provides functionality to open and read Excel files.

--- a/SOLTEC.Core/Adapters/Excel/DefaultFileOpener.cs
+++ b/SOLTEC.Core/Adapters/Excel/DefaultFileOpener.cs
@@ -5,8 +5,8 @@
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// IFileOpener fileOpener = new DefaultFileOpener();
-/// using Stream stream = fileOpener.Open("C:\\data\\report.xlsx");
+/// IFileOpener _fileOpener = new DefaultFileOpener();
+/// using Stream _stream = _fileOpener.Open("C:\\data\\report.xlsx");
 /// ]]>
 /// </example>
 public class DefaultFileOpener : IFileOpener

--- a/SOLTEC.Core/Adapters/Excel/ExcelReaderFactoryWrapper.cs
+++ b/SOLTEC.Core/Adapters/Excel/ExcelReaderFactoryWrapper.cs
@@ -1,6 +1,6 @@
-﻿using ExcelDataReader;
+﻿namespace SOLTEC.Core.Adapters.Excel;
 
-namespace SOLTEC.Core.Adapters.Excel;
+using ExcelDataReader;
 
 /// <summary>
 /// Default wrapper around <see cref="ExcelReaderFactory"/> to create Excel readers.

--- a/SOLTEC.Core/Adapters/Excel/ExcelReaderFactoryWrapper.cs
+++ b/SOLTEC.Core/Adapters/Excel/ExcelReaderFactoryWrapper.cs
@@ -7,8 +7,8 @@ using ExcelDataReader;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// IExcelReaderFactoryWrapper factory = new ExcelReaderFactoryWrapper();
-/// using var reader = factory.CreateReader(stream, new ExcelReaderConfiguration());
+/// IExcelReaderFactoryWrapper _factory = new ExcelReaderFactoryWrapper();
+/// using var _reader = _factory.CreateReader(_stream, new ExcelReaderConfiguration());
 /// ]]>
 /// </example>
 public class ExcelReaderFactoryWrapper : IExcelReaderFactoryWrapper

--- a/SOLTEC.Core/Adapters/Excel/IExcelReaderFactoryWrapper.cs
+++ b/SOLTEC.Core/Adapters/Excel/IExcelReaderFactoryWrapper.cs
@@ -1,6 +1,6 @@
-﻿using ExcelDataReader;
+﻿namespace SOLTEC.Core.Adapters.Excel;
 
-namespace SOLTEC.Core.Adapters.Excel;
+using ExcelDataReader;
 
 /// <summary>
 /// Defines a factory for creating instances of <see cref="IExcelDataReader"/>.

--- a/SOLTEC.Core/Adapters/Excel/IExcelReaderFactoryWrapper.cs
+++ b/SOLTEC.Core/Adapters/Excel/IExcelReaderFactoryWrapper.cs
@@ -7,8 +7,8 @@ using ExcelDataReader;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// IExcelReaderFactoryWrapper factory = new ExcelReaderFactoryWrapper();
-/// using var reader = factory.CreateReader(stream, new ExcelReaderConfiguration());
+/// IExcelReaderFactoryWrapper _factory = new ExcelReaderFactoryWrapper();
+/// using var reader = _factory.CreateReader(_stream, new ExcelReaderConfiguration());
 /// ]]>
 /// </example>
 public interface IExcelReaderFactoryWrapper

--- a/SOLTEC.Core/Adapters/Excel/IExcelReaderFactoryWrapper.cs
+++ b/SOLTEC.Core/Adapters/Excel/IExcelReaderFactoryWrapper.cs
@@ -8,7 +8,7 @@ using ExcelDataReader;
 /// <example>
 /// <![CDATA[
 /// IExcelReaderFactoryWrapper _factory = new ExcelReaderFactoryWrapper();
-/// using var reader = _factory.CreateReader(_stream, new ExcelReaderConfiguration());
+/// using var _reader = _factory.CreateReader(_stream, new ExcelReaderConfiguration());
 /// ]]>
 /// </example>
 public interface IExcelReaderFactoryWrapper

--- a/SOLTEC.Core/Adapters/Excel/IFileOpener.cs
+++ b/SOLTEC.Core/Adapters/Excel/IFileOpener.cs
@@ -5,8 +5,8 @@
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// IFileOpener fileOpener = new DefaultFileOpener();
-/// using Stream stream = fileOpener.Open("path/to/file.xlsx");
+/// IFileOpener _fileOpener = new DefaultFileOpener();
+/// using Stream _stream = _fileOpener.Open("path/to/file.xlsx");
 /// ]]>
 /// </example>
 public interface IFileOpener

--- a/SOLTEC.Core/Adapters/ExcelAdapter.cs
+++ b/SOLTEC.Core/Adapters/ExcelAdapter.cs
@@ -24,7 +24,7 @@ public class ExcelAdapter : Adapter
     /// <returns>An enumerable of mapped objects.</returns>
     /// <example>
     /// <![CDATA[
-    /// var result = new ExcelAdapter().Execute<MyModel>("data.xlsx", true, "Sheet1");
+    /// var _result = new ExcelAdapter().Execute<MyModel>("data.xlsx", true, "Sheet1");
     /// ]]>
     /// </example>
     public virtual IEnumerable<T> Execute<T>(string pathFile, bool headerRow = false, string? sheetName = null)
@@ -59,8 +59,8 @@ public class ExcelAdapter : Adapter
     /// <returns>An enumerable of mapped objects.</returns>
     /// <example>
     /// <![CDATA[
-    /// using var stream = File.OpenRead("data.xlsx");
-    /// var result = new ExcelAdapter().Execute<MyModel>(stream, true);
+    /// using var _stream = File.OpenRead("data.xlsx");
+    /// var _result = new ExcelAdapter().Execute<MyModel>(_stream, true);
     /// ]]>
     /// </example>
     public virtual IEnumerable<T> Execute<T>(Stream stream, bool headerRow = false, string? sheetName = null)

--- a/SOLTEC.Core/Adapters/ExcelAdapter.cs
+++ b/SOLTEC.Core/Adapters/ExcelAdapter.cs
@@ -8,8 +8,8 @@ using NPOI.OpenXml4Net.Exceptions;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// var adapter = new ExcelAdapter();
-/// var items = adapter.Execute<MyModel>("file.xlsx", true);
+/// var _adapter = new ExcelAdapter();
+/// var _items = _adapter.Execute<MyModel>("file.xlsx", true);
 /// ]]>
 /// </example>
 public class ExcelAdapter : Adapter

--- a/SOLTEC.Core/Adapters/ExcelAdapter.cs
+++ b/SOLTEC.Core/Adapters/ExcelAdapter.cs
@@ -1,7 +1,7 @@
-﻿using Ganss.Excel;
-using NPOI.OpenXml4Net.Exceptions;
+﻿namespace SOLTEC.Core.Adapters;
 
-namespace SOLTEC.Core.Adapters;
+using Ganss.Excel;
+using NPOI.OpenXml4Net.Exceptions;
 
 /// <summary>
 /// Adapter that reads Excel files and maps rows to strongly typed objects using ExcelMapper.

--- a/SOLTEC.Core/Adapters/Exceptions/AdapterException.cs
+++ b/SOLTEC.Core/Adapters/Exceptions/AdapterException.cs
@@ -1,8 +1,8 @@
-﻿using SOLTEC.Core.Enums;
+﻿namespace SOLTEC.Core.Adapters.Exceptions;
+
+using SOLTEC.Core.Enums;
 using SOLTEC.Core.Exceptions;
 using System.Net;
-
-namespace SOLTEC.Core.Adapters.Exceptions;
 
 /// <summary>
 /// Exception thrown when an adapter operation fails with a specific error reason.

--- a/SOLTEC.Core/Connections/Commands/SoapCommand.cs
+++ b/SOLTEC.Core/Connections/Commands/SoapCommand.cs
@@ -13,20 +13,20 @@
 /// <example>
 /// <![CDATA[
 /// // Example of how to create and use a SoapCommand:
-/// var parameters = new Dictionary<string, string>
+/// var _parameters = new Dictionary<string, string>
 /// {
 ///     { "Parameter1", "Value1" },
 ///     { "Parameter2", "Value2" }
 /// };
 /// 
-/// var soapCommand = new SoapCommand(
+/// var _soapCommand = new SoapCommand(
 ///     "https://example.com/soap",
 ///     "ActionName",
 ///     "MethodName",
 ///     "http://example.com/namespace",
 ///     "username",
 ///     "password",
-///     parameters
+///     _parameters
 /// );
 /// ]]>
 /// </example>

--- a/SOLTEC.Core/Connections/Exceptions/HttpCoreException.cs
+++ b/SOLTEC.Core/Connections/Exceptions/HttpCoreException.cs
@@ -1,8 +1,8 @@
-﻿using SOLTEC.Core.Enums;
+﻿namespace SOLTEC.Core.Connections.Exceptions;
+
+using SOLTEC.Core.Enums;
 using SOLTEC.Core.Exceptions;
 using System.Net;
-
-namespace SOLTEC.Core.Connections.Exceptions;
 
 /// <summary>
 /// Represents an exception specific to HTTP core operations, extending <see cref="ResultException"/>.

--- a/SOLTEC.Core/Connections/Exceptions/SoapCoreException.cs
+++ b/SOLTEC.Core/Connections/Exceptions/SoapCoreException.cs
@@ -1,7 +1,7 @@
-﻿using SOLTEC.Core.Exceptions;
-using System.Net;
+﻿namespace SOLTEC.Core.Connections.Exceptions;
 
-namespace SOLTEC.Core.Connections.Exceptions;
+using SOLTEC.Core.Exceptions;
+using System.Net;
 
 /// <summary>
 /// Represents an exception specific to SOAP core operations, extending <see cref="ResultException"/>.

--- a/SOLTEC.Core/Connections/Exceptions/SoapCoreException.cs
+++ b/SOLTEC.Core/Connections/Exceptions/SoapCoreException.cs
@@ -11,7 +11,7 @@ using System.Net;
 /// using System.Net;
 /// using SOLTEC.Core.Connections.Exceptions;
 /// 
-/// var exception = new SoapCoreException(
+/// var _exception = new SoapCoreException(
 ///     "InvalidInput",
 ///     "Request body is not valid",
 ///     HttpStatusCode.BadRequest,
@@ -31,7 +31,7 @@ public class SoapCoreException : ResultException
     /// <param name="errorMessage">Optional detailed error message.</param>
     /// <example>
     /// <![CDATA[
-    /// var exception = new SoapCoreException(
+    /// var _exception = new SoapCoreException(
     ///     "InvalidInput",
     ///     "Request body is not valid",
     ///     HttpStatusCode.BadRequest,

--- a/SOLTEC.Core/Connections/HttpCore.cs
+++ b/SOLTEC.Core/Connections/HttpCore.cs
@@ -14,8 +14,8 @@ using System.Text;
 /// <example>
 /// Example usage:
 /// <![CDATA[
-/// var client = new HttpCore();
-/// var result = await client.GetAsync&lt;MyDto&gt;("https://api.example.com/data");
+/// var _client = new HttpCore();
+/// var _result = await _client.GetAsync&lt;MyDto&gt;("https://api.example.com/data");
 /// ]]>
 /// </example>
 public class HttpCore
@@ -29,7 +29,7 @@ public class HttpCore
     /// <returns>Deserialized object of type <typeparamref name="T"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = await new HttpCore().GetAsync&lt;User&gt;("https://api.example.com/users/1");
+    /// var _response = await new HttpCore().GetAsync&lt;User&gt;("https://api.example.com/users/1");
     /// ]]>
     /// </example>
     public virtual async Task<T?> GetAsync<T>(string uri, Dictionary<string, string>? headerParameters = null)
@@ -52,6 +52,11 @@ public class HttpCore
     /// <param name="uri">The target URI.</param>
     /// <param name="headerParameters">Optional headers to include in the request.</param>
     /// <returns>A list of <typeparamref name="T"/> objects.</returns>
+    /// <example>
+    /// <![CDATA[
+    /// var _response = await new HttpCore().GetAsync&lt;User&gt;("https://api.example.com/users/1", _newUser);
+    /// ]]>
+    /// </example>
     public virtual async Task<IList<T>?> GetAsyncList<T>(string uri, Dictionary<string, string>? headerParameters = null)
     {
         using var _client = CreateConfiguredHttpClient(headerParameters);
@@ -72,7 +77,7 @@ public class HttpCore
     /// <param name="headerParameters">Optional headers to include in the request.</param>
     /// <example>
     /// <![CDATA[
-    /// var response = await new HttpCore().PostAsync&lt;User&gt;("https://api.example.com/users", newUser);
+    /// var _response = await new HttpCore().PostAsync&lt;User&gt;("https://api.example.com/users", _newUser);
     /// ]]>
     /// </example>
     public virtual async Task PostAsync(string uri, Dictionary<string, string>? headerParameters = null)
@@ -147,7 +152,7 @@ public class HttpCore
     /// <param name="headerParameters">Optional headers to include in the request.</param>
     /// <example>
     /// <![CDATA[
-    /// var response = await new HttpCore().PutAsync&lt;User&gt;("https://api.example.com/users/1", updatedUser);
+    /// var _response = await new HttpCore().PutAsync&lt;User&gt;("https://api.example.com/users/1", _updatedUser);
     /// ]]>
     /// </example>
     public virtual async Task PutAsync(string uri, Dictionary<string, string>? headerParameters = null)
@@ -224,7 +229,7 @@ public class HttpCore
     /// <returns>The deserialized response object.</returns>
     /// <example>
     /// <![CDATA[
-    /// var result = await new HttpCore().DeleteAsync<User>("https://api.example.com/users/1");
+    /// var _result = await new HttpCore().DeleteAsync<User>("https://api.example.com/users/1");
     /// ]]>
     /// </example>
     public virtual async Task<TResult?> DeleteAsync<TResult>(string uri, Dictionary<string, string>? headerParameters = null)
@@ -253,8 +258,8 @@ public class HttpCore
     /// </exception>
     /// <example>
     /// <![CDATA[
-    /// var response = await httpClient.GetAsync("https://api.example.com/resource"); 
-    /// await ValidateStatusResponse(response);
+    /// var _response = await httpClient.GetAsync("https://api.example.com/resource"); 
+    /// await ValidateStatusResponse(_response);
     /// ]]>
     /// </example>
     protected static async Task ValidateStatusResponse(HttpResponseMessage response)
@@ -284,8 +289,8 @@ public class HttpCore
     /// <exception cref="HttpCoreException">Thrown if the response contains a known error structure.</exception>
     /// <example>
     /// <![CDATA[
-    /// var response = await client.GetStringAsync("http://api/test");
-    /// ValidateResult(response);
+    /// var _response = await client.GetStringAsync("http://api/test");
+    /// ValidateResult(_response);
     /// ]]>
     /// </example>
     protected static void ValidateResult(string result)

--- a/SOLTEC.Core/Connections/HttpCore.cs
+++ b/SOLTEC.Core/Connections/HttpCore.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿namespace SOLTEC.Core.Connections;
+
+using Newtonsoft.Json;
 using SOLTEC.Core.Connections.Exceptions;
 using SOLTEC.Core.DTOS;
 using SOLTEC.Core.Enums;
 using System.Net;
 using System.Security.Authentication;
 using System.Text;
-
-namespace SOLTEC.Core.Connections;
 
 /// <summary>
 /// Provides utility methods for performing HTTP operations (GET, POST, PUT, DELETE) with optional headers and validation.

--- a/SOLTEC.Core/Connections/SoapCore.cs
+++ b/SOLTEC.Core/Connections/SoapCore.cs
@@ -27,7 +27,7 @@ using System.Xml.Serialization;
 ///     "http://example.com/namespace",
 ///     "username",
 ///     "password",
-///     parameters
+///     _parameters
 /// );
 /// 
 /// var _soapCore = new SoapCore();
@@ -40,11 +40,11 @@ using System.Xml.Serialization;
 /// <param name="httpClient">Optional HttpClient instance. If not provided, a default one will be created.</param>
 public class SoapCore(HttpClient? httpClient = null)
 {
-    private const string gcSoapEnvelopeNamespace = "http://schemas.xmlsoap.org/soap/envelope/";
-    private const string gcContentType = "text/xml";
-    private const string gcSoapActionHeader = "SOAPAction";
+    private const string _gcSoapEnvelopeNamespace = "http://schemas.xmlsoap.org/soap/envelope/";
+    private const string _gcContentType = "text/xml";
+    private const string _gcSoapActionHeader = "SOAPAction";
 
-    private readonly HttpClient gHttpClient = httpClient ?? CreateDefaultHttpClient();
+    private readonly HttpClient _gHttpClient = httpClient ?? CreateDefaultHttpClient();
 
     /// <summary>
     /// Sends a SOAP request using the provided command and returns the deserialized response.
@@ -68,7 +68,7 @@ public class SoapCore(HttpClient? httpClient = null)
 
     private static StringContent CreateContent(string action, string soapEnvelope)
     {
-        var _content = new StringContent(soapEnvelope, Encoding.UTF8, gcContentType);
+        var _content = new StringContent(soapEnvelope, Encoding.UTF8, _gcContentType);
         AddSoapAction(action, _content);
 
         return _content;
@@ -76,11 +76,11 @@ public class SoapCore(HttpClient? httpClient = null)
 
     private async Task<T> TryPost<T>(string url, StringContent content, string username, string password)
     {
-        AuthenticationHeader(username, password, gHttpClient);
+        AuthenticationHeader(username, password, _gHttpClient);
 
         try
         {
-            var _response = await gHttpClient.PostAsync(url, content);
+            var _response = await _gHttpClient.PostAsync(url, content);
             _response.EnsureSuccessStatusCode();
             var _result = await _response.Content.ReadAsStringAsync();
 
@@ -100,7 +100,7 @@ public class SoapCore(HttpClient? httpClient = null)
     private static void AddSoapAction(string action, StringContent content)
     {
         if (string.IsNullOrEmpty(action)) return;
-        content.Headers.Add(gcSoapActionHeader, action);
+        content.Headers.Add(_gcSoapActionHeader, action);
     }
 
     private static string CreateSoapEnvelope(string soapMethod, string soapNamespace, Dictionary<string, string> parameters)
@@ -108,7 +108,7 @@ public class SoapCore(HttpClient? httpClient = null)
         var _soapBody = new StringBuilder();
 
         _soapBody.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-        _soapBody.AppendFormat("<soap:Envelope xmlns:soap=\"{0}\">", gcSoapEnvelopeNamespace);
+        _soapBody.AppendFormat("<soap:Envelope xmlns:soap=\"{0}\">", _gcSoapEnvelopeNamespace);
         _soapBody.Append("<soap:Body>");
         _soapBody.AppendFormat("<{0} xmlns=\"{1}\">", soapMethod, soapNamespace);
 

--- a/SOLTEC.Core/Connections/SoapCore.cs
+++ b/SOLTEC.Core/Connections/SoapCore.cs
@@ -14,13 +14,13 @@ using System.Xml.Serialization;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// var parameters = new Dictionary<string, string>
+/// var _parameters = new Dictionary<string, string>
 /// {
 ///     { "Param1", "Value1" },
 ///     { "Param2", "Value2" }
 /// };
 /// 
-/// var soapCommand = new SoapCommand(
+/// var _soapCommand = new SoapCommand(
 ///     "https://example.com/soap",
 ///     "ActionName",
 ///     "MethodName",
@@ -30,8 +30,8 @@ using System.Xml.Serialization;
 ///     parameters
 /// );
 /// 
-/// var soapCore = new SoapCore();
-/// var response = await soapCore.Post<ResponseType>(soapCommand);
+/// var _soapCore = new SoapCore();
+/// var _response = await _soapCore.Post<ResponseType>(_soapCommand);
 /// ]]>
 /// </example>
 /// <remarks>
@@ -54,8 +54,8 @@ public class SoapCore(HttpClient? httpClient = null)
     /// <returns>The deserialized response object of type T.</returns>
     /// <example>
     /// <![CDATA[
-    /// var soapCore = new SoapCore();
-    /// var result = await soapCore.Post<ResponseType>(soapCommand);
+    /// var _soapCore = new SoapCore();
+    /// var _result = await soapCore.Post<ResponseType>(_soapCommand);
     /// ]]>
     /// </example>
     public async Task<T> Post<T>(SoapCommand command)

--- a/SOLTEC.Core/Connections/SoapCore.cs
+++ b/SOLTEC.Core/Connections/SoapCore.cs
@@ -1,4 +1,6 @@
-﻿using SOLTEC.Core.Connections.Commands;
+﻿namespace SOLTEC.Core.Connections;
+
+using SOLTEC.Core.Connections.Commands;
 using SOLTEC.Core.Connections.Exceptions;
 using SOLTEC.Core.Enums;
 using System.Net;
@@ -6,8 +8,6 @@ using System.Net.Http.Headers;
 using System.Security.Authentication;
 using System.Text;
 using System.Xml.Serialization;
-
-namespace SOLTEC.Core.Connections;
 
 /// <summary>
 /// Provides methods to send SOAP requests and handle SOAP responses.

--- a/SOLTEC.Core/DTOS/ProblemDetailsDto.cs
+++ b/SOLTEC.Core/DTOS/ProblemDetailsDto.cs
@@ -6,7 +6,7 @@
 /// <example>
 /// Example of usage:
 /// <![CDATA[
-/// var problem = new ProblemDetailsDto
+/// var _problem = new ProblemDetailsDto
 /// {
 ///     Type = "https://example.com/validation-error",
 ///     Title = "One or more validation errors occurred.",

--- a/SOLTEC.Core/Encryptions/Encryption.cs
+++ b/SOLTEC.Core/Encryptions/Encryption.cs
@@ -9,7 +9,7 @@ using System.Text;
 /// <example>
 /// Example of generating a SHA256 hash:
 /// <![CDATA[
-/// var hash = new Encryptions().GenerateSHA256("hello world");
+/// var _hash = new Encryptions().GenerateSHA256("hello world");
 /// ]]>
 /// </example>
 public class Encryption
@@ -20,7 +20,7 @@ public class Encryption
     /// <param name="maxSize">The length of the generated key.</param>
     /// <example>
     /// <![CDATA[
-    /// var key = new Encryption().GenerateUniqueKey(16);
+    /// var _key = new Encryption().GenerateUniqueKey(16);
     /// ]]>
     /// </example>
     public virtual string GenerateUniqueKey(int maxSize = 10)
@@ -46,7 +46,7 @@ public class Encryption
     /// <param name="secret">The secret key used for encryption.</param>
     /// <example>
     /// <![CDATA[
-    /// var token = new Encryption().CreateTokenHMACSHA256("data", "secret");
+    /// var _token = new Encryption().CreateTokenHMACSHA256("data", "secret");
     /// ]]>
     /// </example>
     public virtual string CreateTokenHMACSHA256(string message, string secret)
@@ -64,7 +64,7 @@ public class Encryption
     /// </summary>
     /// <param name="message">The input string.</param>
     /// <example><![CDATA[
-    /// var hash = new Encryption().CreateMd5("test");
+    /// var _hash = new Encryption().CreateMd5("test");
     /// ]]></example>
     public virtual string CreateMD5(string message)
     {
@@ -79,7 +79,7 @@ public class Encryption
     /// </summary>
     /// <example>
     /// <![CDATA[
-    /// var token = new Encryption().Token();
+    /// var _token = new Encryption().Token();
     /// ]]>
     /// </example>
     public virtual string Token()
@@ -101,7 +101,7 @@ public class Encryption
     /// <param name="input">The encoded string.</param>
     /// <example>
     /// <![CDATA[
-    /// var decoded = new Encryption().Base64Decode("SGVsbG8h");
+    /// var _decoded = new Encryption().Base64Decode("SGVsbG8h");
     /// ]]>
     /// </example>
     public virtual string Base64Decode(string input)
@@ -117,7 +117,7 @@ public class Encryption
     /// <param name="input">The input string.</param>
     /// <example>
     /// <![CDATA[
-    /// var encoded = new Encryption().Base64Encode("Hello!");
+    /// var _encoded = new Encryption().Base64Encode("Hello!");
     /// ]]>
     /// </example>
     public virtual string Base64Encode(string input)
@@ -132,7 +132,7 @@ public class Encryption
     /// </summary>
     /// <param name="message">The input string.</param>
     /// <example><![CDATA[
-    /// var sha1 = new Encryption().GenerateSHA1("abc");
+    /// var _sha1 = new Encryption().GenerateSHA1("abc");
     /// ]]></example>
     public virtual string GenerateSHA1(string message)
     {
@@ -147,7 +147,7 @@ public class Encryption
     /// <param name="message">The input string.</param>
     /// <example>
     /// <![CDATA[
-    /// var sha = new Encryption().GenerateSHA256("password");
+    /// var _sha256 = new Encryption().GenerateSHA256("password");
     /// ]]>
     /// </example>
     public virtual string GenerateSHA256(string message)
@@ -162,7 +162,7 @@ public class Encryption
     /// </summary>
     /// <param name="message">The input string.</param>
     /// <example><![CDATA[
-    /// var sha384 = new Encryption().GenerateSHA384("abc");
+    /// var _sha384 = new Encryption().GenerateSHA384("abc");
     /// ]]></example>
     public virtual string GenerateSHA384(string message)
     {
@@ -176,7 +176,7 @@ public class Encryption
     /// </summary>
     /// <param name="message">The input string.</param>
     /// <example><![CDATA[
-    /// var sha384 = new Encryption().GenerateSHA512("abc");
+    /// var _sha384 = new Encryption().GenerateSHA512("abc");
     /// ]]></example>
     public virtual string GenerateSHA512(string message)
     {
@@ -191,7 +191,7 @@ public class Encryption
     /// <param name="data">The string to encrypt.</param>
     /// <param name="password">The password for encryption.</param>
     /// <example><![CDATA[
-    /// var encrypted = new Encryption().Encrypt("secret", "password123");
+    /// var _encrypted = new Encryption().Encrypt("secret", "password123");
     /// ]]></example>
     public virtual string? Encrypt(string data, string password)
     {
@@ -209,7 +209,7 @@ public class Encryption
     /// <param name="encryptedData">The encrypted base64 string.</param>
     /// <param name="password">The password used for encryption.</param>
     /// <example><![CDATA[
-    /// var decrypted = new Encryption().Decrypt(encrypted, "password123");
+    /// var _decrypted = new Encryption().Decrypt(encrypted, "password123");
     /// ]]></example>
     public virtual string? Decrypt(string encryptedData, string password)
     {

--- a/SOLTEC.Core/Encryptions/Encryption.cs
+++ b/SOLTEC.Core/Encryptions/Encryption.cs
@@ -1,7 +1,7 @@
-﻿using System.Security.Cryptography;
-using System.Text;
+﻿namespace SOLTEC.Core.Encryptions;
 
-namespace SOLTEC.Core.Encryptions;
+using System.Security.Cryptography;
+using System.Text;
 
 /// <summary>
 /// Provides utility methods for various encryption, hashing, and encoding operations.

--- a/SOLTEC.Core/Encryptions/Encryption.cs
+++ b/SOLTEC.Core/Encryptions/Encryption.cs
@@ -25,15 +25,15 @@ public class Encryption
     /// </example>
     public virtual string GenerateUniqueKey(int maxSize = 10)
     {
-        const string _cchars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+        const string _chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
         var _data = new byte[maxSize];
         using var _rng = RandomNumberGenerator.Create();
         _rng.GetBytes(_data);
         var _result = new StringBuilder(maxSize);
 
-        foreach (var _b in _data)
+        foreach (var _byte in _data)
         {
-            _result.Append(_cchars[_b % _cchars.Length]);
+            _result.Append(_chars[_byte % _chars.Length]);
         }
 
         return _result.ToString();

--- a/SOLTEC.Core/Enums/FileTypeEnum.cs
+++ b/SOLTEC.Core/Enums/FileTypeEnum.cs
@@ -9,8 +9,8 @@
 /// <example>
 /// Example usage:
 /// <![CDATA[
-/// FileTypeEnum type = FileTypeEnum.Json;
-/// if (type == FileTypeEnum.Xlsx)
+/// FileTypeEnum _type = FileTypeEnum.Json;
+/// if (_type == FileTypeEnum.Xlsx)
 /// {
 ///     Console.WriteLine("Exporting to Excel format.");
 /// }

--- a/SOLTEC.Core/Enums/HttpCoreErrorEnum.cs
+++ b/SOLTEC.Core/Enums/HttpCoreErrorEnum.cs
@@ -6,8 +6,8 @@
 /// <example>
 /// Example usage:
 /// <![CDATA[
-/// HttpCoreErrorEnum httpError = HttpCoreErrorEnum.Json;
-/// if (httpError == HttpCoreErrorEnum.BadRequest)
+/// HttpCoreErrorEnum _httpError = HttpCoreErrorEnum.Json;
+/// if (_httpError == HttpCoreErrorEnum.BadRequest)
 /// {
 ///     Console.WriteLine("Http protocol response with Error (BaddReques) EndPoint not found.");
 /// }

--- a/SOLTEC.Core/Exceptions/ResultException.cs
+++ b/SOLTEC.Core/Exceptions/ResultException.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
+﻿namespace SOLTEC.Core.Exceptions;
 
-namespace SOLTEC.Core.Exceptions;
+using System.Net;
 
 /// <summary>
 /// Represents a custom exception that includes additional context such as a key, reason, error message, and HTTP status code.

--- a/SOLTEC.Core/Extensions/ArrayExtensions.cs
+++ b/SOLTEC.Core/Extensions/ArrayExtensions.cs
@@ -9,7 +9,7 @@
 /// var _original = new[] { 1, 2, 3 };
 /// var _extended = _original.Add(4);
 /// // Adding an item to the beginning
-/// var _prepended = _original.Add(0, prepend: true);
+/// var _prepended = _original.Add(0, true);
 /// ]]>
 /// </example>
 public static class ArrayExtensions
@@ -26,7 +26,7 @@ public static class ArrayExtensions
     /// <![CDATA[
     /// var _original = new[] { "a", "b" };
     /// var _newArr = _original.Add("c");
-    /// var _prependedArr = _original.Add("x", prepend: true);
+    /// var _prependedArr = _original.Add("x", true);
     /// ]]>
     /// </example>
     public static T[] Add<T>(this T[] target, T item, bool prepend = false)

--- a/SOLTEC.Core/Extensions/ArrayExtensions.cs
+++ b/SOLTEC.Core/Extensions/ArrayExtensions.cs
@@ -6,10 +6,10 @@
 /// <example>
 /// <![CDATA[
 /// // Adding an item to the end
-/// var original = new[] { 1, 2, 3 };
-/// var extended = original.Add(4);
+/// var _original = new[] { 1, 2, 3 };
+/// var _extended = _original.Add(4);
 /// // Adding an item to the beginning
-/// var prepended = original.Add(0, prepend: true);
+/// var _prepended = _original.Add(0, prepend: true);
 /// ]]>
 /// </example>
 public static class ArrayExtensions
@@ -24,9 +24,9 @@ public static class ArrayExtensions
     /// <returns>A new array containing the original elements plus the added item.</returns>
     /// <example>
     /// <![CDATA[
-    /// var original = new[] { "a", "b" };
-    /// var newArr = original.Add("c");
-    /// var prependedArr = original.Add("x", prepend: true);
+    /// var _original = new[] { "a", "b" };
+    /// var _newArr = _original.Add("c");
+    /// var _prependedArr = _original.Add("x", prepend: true);
     /// ]]>
     /// </example>
     public static T[] Add<T>(this T[] target, T item, bool prepend = false)

--- a/SOLTEC.Core/Extensions/DateExtensions.cs
+++ b/SOLTEC.Core/Extensions/DateExtensions.cs
@@ -1,6 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿namespace SOLTEC.Core.Extensions;
 
-namespace SOLTEC.Core.Extensions;
+using System.Text.RegularExpressions;
 
 /// <summary>
 /// Provides extension methods for formatting and parsing <see cref="DateTime"/> values.

--- a/SOLTEC.Core/Extensions/DateExtensions.cs
+++ b/SOLTEC.Core/Extensions/DateExtensions.cs
@@ -8,15 +8,15 @@ using System.Text.RegularExpressions;
 /// <example>
 /// <![CDATA[
 /// // Formatting examples
-/// DateTime? nullableDate = new DateTime(2025, 5, 21, 13, 45, 30);
-/// string dateOnly = nullableDate.ToDateFormat();                  // "20250521"
-/// string dateTime = nullableDate.ToDateFormatWithTime();          // "20250521134530"
-/// DateTime date = DateTime.UtcNow;
-/// string iso8601 = date.ToDateFormatWithTimeISO8601();            // "2025-05-21T13:45:30Z"
+/// DateTime? _nullableDate = new DateTime(2025, 5, 21, 13, 45, 30);
+/// string _dateOnly = _nullableDate.ToDateFormat();                  // "20250521"
+/// string _dateTime = _nullableDate.ToDateFormatWithTime();          // "20250521134530"
+/// DateTime _date = DateTime.UtcNow;
+/// string _iso8601 = _date.ToDateFormatWithTimeISO8601();            // "2025-05-21T13:45:30Z"
 ///
 /// // Parsing examples
-/// string input = "OrderDate:20250521";
-/// DateTime? parsed = DateExtensions.ParsePart(input, @"\d{8}", "yyyyMMdd", CultureInfo.InvariantCulture, null);
+/// string _input = "OrderDate:20250521";
+/// DateTime? _parsed = DateExtensions.ParsePart(_input, @"\d{8}", "yyyyMMdd", CultureInfo.InvariantCulture, null);
 /// ]]>
 /// </example>
 public static class DateExtensions
@@ -28,8 +28,8 @@ public static class DateExtensions
     /// <returns>A string in "yyyyMMdd" format, or empty if <paramref name="date"/> is null.</returns>
     /// <example>
     /// <![CDATA[
-    /// DateTime? date = new DateTime(2025, 5, 21);
-    /// string result = date.ToDateFormat();            // "20250521"
+    /// DateTime? _date = new DateTime(2025, 5, 21);
+    /// string _result = _date.ToDateFormat();            // "20250521"
     /// ]]>
     /// </example>
     public static string ToDateFormat(this DateTime? date)
@@ -44,8 +44,8 @@ public static class DateExtensions
     /// <returns>A string in "yyyyMMddHHmmss" format, or empty if <paramref name="date"/> is null.</returns>
     /// <example>
     /// <![CDATA[
-    /// DateTime? date = new DateTime(2025, 5, 21, 13, 45, 30);
-    /// string result = date.ToDateFormatWithTime();            // "20250521134530"
+    /// DateTime? _date = new DateTime(2025, 5, 21, 13, 45, 30);
+    /// string _result = _date.ToDateFormatWithTime();            // "20250521134530"
     /// ]]>
     /// </example>
     public static string ToDateFormatWithTime(this DateTime? date)
@@ -60,8 +60,8 @@ public static class DateExtensions
     /// <returns>A string in "yyyyMMddHHmmss" format.</returns>
     /// <example>
     /// <![CDATA[
-    /// DateTime date = new DateTime(2025, 5, 21, 13, 45, 30);
-    /// string result = date.ToDateFormatWithTime();            // "20250521134530"
+    /// DateTime _date = new DateTime(2025, 5, 21, 13, 45, 30);
+    /// string _result = _date.ToDateFormatWithTime();            // "20250521134530"
     /// ]]>
     /// </example>
     public static string ToDateFormatWithTime(this DateTime date)
@@ -76,8 +76,8 @@ public static class DateExtensions
     /// <returns>A string in ISO 8601 format.</returns>
     /// <example>
     /// <![CDATA[
-    /// DateTime date = new DateTime(2025, 5, 21, 13, 45, 30);
-    /// string iso = date.ToDateFormatWithTimeISO8601();        // "2025-05-21T13:45:30Z"
+    /// DateTime _date = new DateTime(2025, 5, 21, 13, 45, 30);
+    /// string _iso = _date.ToDateFormatWithTimeISO8601();        // "2025-05-21T13:45:30Z"
     /// ]]>
     /// </example>
     public static string ToDateFormatWithTimeISO8601(this DateTime date)
@@ -103,8 +103,8 @@ public static class DateExtensions
     /// [GeneratedRegex(@"\\d{8}")]
     /// private static partial Regex DateFormat();
     ///
-    /// string input = "Date:20250521";
-    /// DateTime? date = DateExtensions.ParsePart(input, "\\d{8}", "yyyyMMdd", CultureInfo.InvariantCulture, null);
+    /// string _input = "Date:20250521";
+    /// DateTime? _date = DateExtensions.ParsePart(_input, "\\d{8}", "yyyyMMdd", CultureInfo.InvariantCulture, null);
     /// ]]>
     /// </example>
     public static DateTime? ParsePart(string input, string regex, string format, IFormatProvider formatProvider, DateTime? styles)
@@ -145,8 +145,8 @@ public static class DateExtensions
     /// [GeneratedRegex(@"\\d{8}")]
     /// private static partial Regex DateFormat();
     ///
-    /// string input = "Date:20250521";
-    /// DateTime? date = DateExtensions.ParsePart(input, DateFormat(), "yyyyMMdd", CultureInfo.InvariantCulture, null);
+    /// string _input = "Date:20250521";
+    /// DateTime? _date = DateExtensions.ParsePart(_input, DateFormat(), "yyyyMMdd", CultureInfo.InvariantCulture, null);
     /// ]]>
     /// </example>
     public static DateTime? ParsePart(string input, Regex regex, string format, IFormatProvider formatProvider, DateTime? styles)
@@ -185,8 +185,8 @@ public static class DateExtensions
     /// <returns>A nullable <see cref="DateTime"/> parsed from <paramref name="input"/>, or <paramref name="styles"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// string input = "20250521134530";
-    /// DateTime? date = DateExtensions.ParseExactOrDefault(input, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, null);
+    /// string _input = "20250521134530";
+    /// DateTime? _date = DateExtensions.ParseExactOrDefault(_input, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, null);
     /// ]]>
     /// </example>
     public static DateTime? ParseExactOrDefault(string input, string format, IFormatProvider formatProvideer, DateTime? styles)

--- a/SOLTEC.Core/Extensions/EnumerableExtensions.cs
+++ b/SOLTEC.Core/Extensions/EnumerableExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System.ComponentModel;
-using System.Data;
+﻿namespace SOLTEC.Core.Extensions;
 
-namespace SOLTEC.Core.Extensions;
+using System.ComponentModel;
+using System.Data;
 
 /// <summary>
 /// Provides extension methods for converting collections to DataTable.

--- a/SOLTEC.Core/Extensions/EnumerableExtensions.cs
+++ b/SOLTEC.Core/Extensions/EnumerableExtensions.cs
@@ -9,12 +9,12 @@ using System.Data;
 /// <example>
 /// <![CDATA[
 /// // Assume a class MyEntity { public int Id { get; set; } public string Name { get; set; } }
-/// var list = new List<MyEntity>
+/// var _list = new List<MyEntity>
 /// {
 ///     new MyEntity { Id = 1, Name = "Alice" },
 ///     new MyEntity { Id = 2, Name = "Bob" }
 /// };
-/// DataTable table = list.ToDataTable();
+/// DataTable _table = list.ToDataTable();
 /// ]]>
 /// </example>
 public static class EnumerableExtensions
@@ -31,8 +31,8 @@ public static class EnumerableExtensions
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="data"/> is null.</exception>
     /// <example>
     /// <![CDATA[
-    /// var names = new[] { "Alice", "Bob" };
-    /// DataTable dt = names.ToDataTable();
+    /// var _names = new[] { "Alice", "Bob" };
+    /// DataTable _dt = _names.ToDataTable();
     /// ]]>
     /// </example>
     public static DataTable ToDataTable<T>(this IEnumerable<T> data)

--- a/SOLTEC.Core/Extensions/IntegerExtensions.cs
+++ b/SOLTEC.Core/Extensions/IntegerExtensions.cs
@@ -6,11 +6,11 @@
 /// <example>
 /// <![CDATA[
 /// // Parsing a valid numeric string
-/// int? parsed = IntegerExtensions.ParseOrDefault("123", null); // 123
+/// int? _parsed = IntegerExtensions.ParseOrDefault("123", null); // 123
 /// // Parsing an invalid string returns the provided default
-/// int? defaulted = IntegerExtensions.ParseOrDefault("abc", 42); // 42
+/// int? _defaulted = IntegerExtensions.ParseOrDefault("abc", 42); // 42
 /// // Null input also returns default
-/// int? nullDefault = IntegerExtensions.ParseOrDefault(null, 0); // 0
+/// int? _nullDefault = IntegerExtensions.ParseOrDefault(null, 0); // 0
 /// ]]>
 /// </example>
 public static class IntegerExtensions
@@ -25,8 +25,8 @@ public static class IntegerExtensions
     /// </returns>
     /// <example>
     /// <![CDATA[
-    /// int? result1 = IntegerExtensions.ParseOrDefault("100", null);   // 100
-    /// int? result2 = IntegerExtensions.ParseOrDefault("xyz", -1);     // -1
+    /// int? _result1 = IntegerExtensions.ParseOrDefault("100", null);   // 100
+    /// int? _result2 = IntegerExtensions.ParseOrDefault("xyz", -1);     // -1
     /// ]]>
     /// </example>
     public static int? ParseOrDefault(string s, int? defaultValue)

--- a/SOLTEC.Core/Extensions/ListExtensions.cs
+++ b/SOLTEC.Core/Extensions/ListExtensions.cs
@@ -6,16 +6,16 @@
 /// <example>
 /// <![CDATA[
 /// // Null list returns true
-/// IList<int> numbers = null;
-/// bool result1 = numbers.IsNullOrEmpty(); // true
+/// IList<int> _numbers = null;
+/// bool _result1 = _numbers.IsNullOrEmpty(); // true
 /// 
 /// // Empty list returns true
-/// numbers = new List<int>();
-/// bool result2 = numbers.IsNullOrEmpty(); // true
+/// _numbers = new List<int>();
+/// bool _result2 = _numbers.IsNullOrEmpty(); // true
 /// 
 /// // List with elements returns false
-/// numbers.Add(5);
-/// bool result3 = numbers.IsNullOrEmpty(); // false
+/// _numbers.Add(5);
+/// bool _result3 = _numbers.IsNullOrEmpty(); // false
 /// ]]>
 /// </example>
 public static class ListExtensions
@@ -30,12 +30,12 @@ public static class ListExtensions
     /// </returns>
     /// <example>
     /// <![CDATA[
-    /// IList<string> names = null;
-    /// bool isEmpty = names.IsNullOrEmpty();   // true
-    /// names = new List<string>();
-    /// isEmpty = names.IsNullOrEmpty();        // true
+    /// IList<string> _names = null;
+    /// bool _isEmpty = _names.IsNullOrEmpty();   // true
+    /// _names = new List<string>();
+    /// _isEmpty = _names.IsNullOrEmpty();        // true
     /// names.Add("Alice");
-    /// isEmpty = names.IsNullOrEmpty();        // false
+    /// _isEmpty = _names.IsNullOrEmpty();        // false
     /// ]]>
     /// </example>
     public static bool IsNullOrEmpty<T>(this IList<T> collection)

--- a/SOLTEC.Core/Extensions/StringExtensions.cs
+++ b/SOLTEC.Core/Extensions/StringExtensions.cs
@@ -12,9 +12,9 @@ using System.Text.RegularExpressions;
 /// <example>
 /// <![CDATA[
 /// // Example usage:
-/// string s1 = "1,234.56";
-/// float f1 = s1.ToFloatFlexible();
-/// Console.WriteLine(f1); // Output: 1234.56
+/// string _s1 = "1,234.56";
+/// float _f1 = _s1.ToFloatFlexible();
+/// Console.WriteLine(_f1); // Output: 1234.56
 /// ]]>
 /// </example>
 public static partial class StringExtensions
@@ -29,14 +29,14 @@ public static partial class StringExtensions
     /// <example>
     /// <![CDATA[
     /// // Parsing a string with comma as decimal separator:
-    /// string value1 = "1234,56";
-    /// float result1 = value1.ToFloatFlexible();
-    /// // result1 == 1234.56f
+    /// string _value1 = "1234,56";
+    /// float _result1 = _value1.ToFloatFlexible();
+    /// // _result1 == 1234.56f
     ///
     /// // Parsing a string with dot as decimal separator:
-    /// string value2 = "1234.56";
-    /// float result2 = value2.ToFloatFlexible();
-    /// // result2 == 1234.56f
+    /// string _value2 = "1234.56";
+    /// float _result2 = _value2.ToFloatFlexible();
+    /// // _result2 == 1234.56f
     /// ]]>
     /// </example>
     public static float ToFloatFlexible(this string input)

--- a/SOLTEC.Core/Extensions/StringExtensions.cs
+++ b/SOLTEC.Core/Extensions/StringExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System.Globalization;
-using System.Text.RegularExpressions;
+﻿namespace SOLTEC.Core.Extensions;
 
-namespace SOLTEC.Core.Extensions;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 /// <summary>
 /// Provides extension methods for parsing numeric strings to <see cref="float"/>.

--- a/SOLTEC.Core/FileManagment.cs
+++ b/SOLTEC.Core/FileManagment.cs
@@ -9,8 +9,8 @@ using System.Text;
 /// </summary>
 /// <example>
 /// <![CDATA[
-/// var fileManager = new FileManagment();
-/// string name = fileManager.ExtractFileNameFromPath(@"C:\docs\file.txt"); // "file"
+/// var _fileManager = new FileManagment();
+/// string _name = fileManager.ExtractFileNameFromPath(@"C:\docs\file.txt"); // "file"
 /// ]]>
 /// </example>
 public class FileManagment
@@ -22,7 +22,7 @@ public class FileManagment
     /// <returns>The file name without extension, or an empty string if the path is invalid.</returns>
     /// <example>
     /// <![CDATA[
-    /// var name = ExtractFileNameFromPath(@"C:\files\report.pdf"); // "report"
+    /// var _name = ExtractFileNameFromPath(@"C:\files\report.pdf"); // "report"
     /// ]]>
     /// </example>
     public virtual string ExtractFileNameFromPath(string filePath)
@@ -39,7 +39,7 @@ public class FileManagment
     /// <returns>The extension without the dot, or an empty string if the path is invalid.</returns>
     /// <example>
     /// <![CDATA[
-    /// var ext = ExtractExtensionFileFromPath(@"file.json"); // "json"
+    /// var _ext = ExtractExtensionFileFromPath(@"file.json"); // "json"
     /// ]]>
     /// </example>
     public virtual string ExtractExtensionFileFromPath(string filePath)
@@ -87,7 +87,7 @@ public class FileManagment
     /// <returns>Enumerable of matching file paths, or empty list if path not found.</returns>
     /// <example>
     /// <![CDATA[
-    /// var jsonFiles = GetAllFilesByTypeFromPath(@"C:\configs", FileTypeEnum.Json);
+    /// var _jsonFiles = GetAllFilesByTypeFromPath(@"C:\configs", FileTypeEnum.Json);
     /// ]]>
     /// </example>
     public virtual IEnumerable<string> GetAllFilesByTypeFromPath(string directoryPath, FileTypeEnum fileTypeEnum)
@@ -157,7 +157,7 @@ public class FileManagment
     /// <returns>File content or empty string if file doesn't exist.</returns>
     /// <example>
     /// <![CDATA[
-    /// string content = await ReadFileAsync(@"notes.txt");
+    /// string _content = await ReadFileAsync(@"notes.txt");
     /// ]]>
     /// </example>
     public virtual async Task<string> ReadFileAsync(string filePath)
@@ -189,7 +189,7 @@ public class FileManagment
     /// <returns>Base64 string or empty string if file not found.</returns>
     /// <example>
     /// <![CDATA[
-    /// string base64 = await ConvertFileToBase64Async("image.png");
+    /// string _base64 = await ConvertFileToBase64Async("image.png");
     /// ]]>
     /// </example>
     public virtual async Task<string> ConvertFileToBase64Async(string filePath)
@@ -208,7 +208,7 @@ public class FileManagment
     /// <returns>MemoryStream with decoded content, or empty stream if input is invalid.</returns>
     /// <example>
     /// <![CDATA[
-    /// using var stream = DecodeBase64ToStream(encodedText);
+    /// using var _stream = DecodeBase64ToStream(encodedText);
     /// ]]>
     /// </example>
     public virtual Stream DecodeBase64ToStream(string base64EncodedData)

--- a/SOLTEC.Core/FileManagment.cs
+++ b/SOLTEC.Core/FileManagment.cs
@@ -1,7 +1,7 @@
-﻿using SOLTEC.Core.Enums;
-using System.Text;
+﻿namespace SOLTEC.Core;
 
-namespace SOLTEC.Core;
+using SOLTEC.Core.Enums;
+using System.Text;
 
 /// <summary>
 /// Provides common file operations such as reading, writing, copying, moving, deleting,

--- a/SOLTEC.Core/ServiceResponse.cs
+++ b/SOLTEC.Core/ServiceResponse.cs
@@ -8,13 +8,13 @@ using System.Net;
 /// <example>
 /// Example of creating a successful response:
 /// <![CDATA[
-/// var response = ServiceResponse.CreateSuccess(200);
+/// var _response = ServiceResponse.CreateSuccess(200);
 /// ]]>
 /// </example>
 /// <example>
 /// Example of creating an error response:
 /// <![CDATA[
-/// var response = ServiceResponse.CreateError(500, "Internal server error");
+/// var _response = ServiceResponse.CreateError(500, "Internal server error");
 /// ]]>
 /// </example>
 public class ServiceResponse
@@ -60,7 +60,7 @@ public class ServiceResponse
     /// <returns>A new successful <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess(200);
+    /// var _response = ServiceResponse.CreateSuccess(200);
     /// ]]>
     /// </example>
     public static ServiceResponse CreateSuccess(int responseCode) => CreateSuccess(responseCode, null);
@@ -71,7 +71,7 @@ public class ServiceResponse
     /// <returns>A new successful <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess(HttpStatusCode.OK);
+    /// var _response = ServiceResponse.CreateSuccess(HttpStatusCode.OK);
     /// ]]>
     /// </example>
     public static ServiceResponse CreateSuccess(HttpStatusCode responseCode) => CreateSuccess((int)responseCode, null);
@@ -83,7 +83,7 @@ public class ServiceResponse
     /// <returns>A new successful <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess(200, null);
+    /// var _response = ServiceResponse.CreateSuccess(200, null);
     /// ]]>
     /// </example>
     public static ServiceResponse CreateSuccess(int responseCode, string[]? warningMessages)
@@ -103,7 +103,7 @@ public class ServiceResponse
     /// <returns>A new successful <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess(HttpStatusCode.OK, null);
+    /// var _response_response = ServiceResponse.CreateSuccess(HttpStatusCode.OK, null);
     /// ]]>
     /// </example>
     public static ServiceResponse CreateSuccess(HttpStatusCode responseCode, string[] warningMessages)
@@ -124,7 +124,7 @@ public class ServiceResponse
     /// <returns>A new error <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(404, "Not found");
+    /// var _error = ServiceResponse<string>.CreateError(404, "Not found");
     /// ]]>
     /// </example>
     public static ServiceResponse CreateError(int responseCode, string errorMessage) => CreateError(responseCode, errorMessage, null);
@@ -136,7 +136,7 @@ public class ServiceResponse
     /// <returns>A new error <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found");
+    /// var _error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found");
     /// ]]>
     /// </example>
     public static ServiceResponse CreateError(HttpStatusCode responseCode, string errorMessage) => CreateError((int)responseCode, errorMessage, null);
@@ -149,7 +149,7 @@ public class ServiceResponse
     /// <returns>A new error <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(404, "Not found", null);
+    /// var _error = ServiceResponse<string>.CreateError(404, "Not found", null);
     /// ]]>
     /// </example>
     public static ServiceResponse CreateError(int responseCode, string errorMessage, string[]? warningMessages)
@@ -171,7 +171,7 @@ public class ServiceResponse
     /// <returns>A new error <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found", null);
+    /// var _error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found", null);
     /// ]]>
     /// </example>
     public static ServiceResponse CreateError(HttpStatusCode responseCode, string errorMessage, string[] warningMessages)
@@ -193,7 +193,7 @@ public class ServiceResponse
     /// <returns>A new warning <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(206, "Partial result");
+    /// var _response = ServiceResponse.CreateWarning(206, "Partial result");
     /// ]]>
     /// </example>
     public static ServiceResponse CreateWarning(int responseCode, string errorMessage) => CreateWarning(responseCode, errorMessage, null);
@@ -205,7 +205,7 @@ public class ServiceResponse
     /// <returns>A new warning <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result");
+    /// var _response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result");
     /// ]]>
     /// </example>
     public static ServiceResponse CreateWarning(HttpStatusCode responseCode, string errorMessage) => CreateWarning((int)responseCode, errorMessage, null);
@@ -218,7 +218,7 @@ public class ServiceResponse
     /// <returns>A new warning <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(206, "Partial result", new[] { "Partial data", "Rate limit applied" });
+    /// var _response = ServiceResponse.CreateWarning(206, "Partial result", new[] { "Partial data", "Rate limit applied" });
     /// ]]>
     /// </example>
     public static ServiceResponse CreateWarning(int responseCode, string warningMessage, string[]? warningMessages)
@@ -240,7 +240,7 @@ public class ServiceResponse
     /// <returns>A new warning <see cref="ServiceResponse"/>.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result", new[] { "Partial data", "Rate limit applied" });
+    /// var _response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result", new[] { "Partial data", "Rate limit applied" });
     /// ]]>
     /// </example>
     public static ServiceResponse CreateWarning(HttpStatusCode responseCode, string errorMessage, string[] warningMessages)

--- a/SOLTEC.Core/ServiceResponse.cs
+++ b/SOLTEC.Core/ServiceResponse.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
+﻿namespace SOLTEC.Core;
 
-namespace SOLTEC.Core;
+using System.Net;
 
 /// <summary>
 /// Represents a standardized structure for service responses, including success or error information.

--- a/SOLTEC.Core/ServiceResponseT.cs
+++ b/SOLTEC.Core/ServiceResponseT.cs
@@ -214,7 +214,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new error response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(206, "Partial result", new[] { "Partial data", "Rate limit applied" });
+    /// var _response = ServiceResponse.CreateWarning(206, "Partial result", new[] { "Partial data", "Rate limit applied" });
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateWarning(int responseCode, string errorMessage, string[]? warningMessages)

--- a/SOLTEC.Core/ServiceResponseT.cs
+++ b/SOLTEC.Core/ServiceResponseT.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
+﻿namespace SOLTEC.Core;
 
-namespace SOLTEC.Core;
+using System.Net;
 
 /// <summary>
 /// Represents a generic version of <see cref="ServiceResponse"/>, allowing the response to include data of any type.

--- a/SOLTEC.Core/ServiceResponseT.cs
+++ b/SOLTEC.Core/ServiceResponseT.cs
@@ -9,14 +9,14 @@ using System.Net;
 /// <example>
 /// Example 1: Creating a successful response with data
 /// <![CDATA[
-/// var data = new User { Id = 1, Name = "John" };
-/// var response = ServiceResponse&lt;User&gt;.CreateSuccess(data, 200);
+/// var _data = new User { Id = 1, Name = "John" };
+/// var _response = ServiceResponse&lt;User&gt;.CreateSuccess(data, 200);
 /// ]]>
 /// </example>
 /// <example>
 /// Example 2: Creating an error response.
 /// <![CDATA[
-/// var response = ServiceResponse&lt;string&gt;.CreateError(400, "Invalid request");
+/// var _response = ServiceResponse&lt;string&gt;.CreateError(400, "Invalid request");
 /// ]]>
 /// </example>
 public class ServiceResponse<T> : ServiceResponse
@@ -51,7 +51,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new successful response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var result = ServiceResponse<string>.CreateSuccess("Done", 200);
+    /// var _result = ServiceResponse<string>.CreateSuccess("Done", 200);
     /// ]]>
     /// </example>
     public static ServiceResponse<T> CreateSuccess(T data, int responseCode) => CreateSuccess(data, responseCode, null);
@@ -63,7 +63,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new successful response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess("OK", HttpStatusCode.OK);
+    /// var _response = ServiceResponse.CreateSuccess("OK", HttpStatusCode.OK);
     /// ]]>
     /// </example>
     public static ServiceResponse<T> CreateSuccess(T data, HttpStatusCode responseCode) => CreateSuccess(data, responseCode, null);
@@ -76,7 +76,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new successful response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess("OK", 200, null);
+    /// var _response = ServiceResponse.CreateSuccess("OK", 200, null);
     /// ]]>
     /// </example>
     public static ServiceResponse<T> CreateSuccess(T data, int responseCode, string[]? warningMessages)
@@ -97,7 +97,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new successful response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateSuccess("OK", HttpStatusCode.OK, null);
+    /// var _response = ServiceResponse.CreateSuccess("OK", HttpStatusCode.OK, null);
     /// ]]>
     /// </example>
     public static ServiceResponse<T> CreateSuccess(T data, HttpStatusCode responseCode, string[]? warningMessages)
@@ -118,7 +118,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new error response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(404, "Not found");
+    /// var _error = ServiceResponse<string>.CreateError(404, "Not found");
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateError(int responseCode, string errorMessage) => CreateError(responseCode, errorMessage, null);
@@ -130,7 +130,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new error response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found");
+    /// var _error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found");
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateError(HttpStatusCode responseCode, string errorMessage) => CreateError((int)responseCode, errorMessage, null);
@@ -143,7 +143,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new error response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(404, "Not found", null);
+    /// var _error = ServiceResponse<string>.CreateError(404, "Not found", null);
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateError(int responseCode, string errorMessage, string[]? warningMessages)
@@ -166,7 +166,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new error response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found", null);
+    /// var _error = ServiceResponse<string>.CreateError(HttpStatusCode.NotFound, "Not found", null);
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateError(HttpStatusCode responseCode, string errorMessage, string[]? warningMessages)
@@ -189,7 +189,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new warning response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(206, "Partial result");
+    /// var _response = ServiceResponse.CreateWarning(206, "Partial result");
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateWarning(int responseCode, string errorMessage) => CreateWarning(responseCode, errorMessage, null);
@@ -201,7 +201,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new erwarningror response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result");
+    /// var _response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result");
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateWarning(HttpStatusCode responseCode, string errorMessage) => CreateWarning((int)responseCode, errorMessage, null);
@@ -237,7 +237,7 @@ public class ServiceResponse<T> : ServiceResponse
     /// <returns>A new warning response.</returns>
     /// <example>
     /// <![CDATA[
-    /// var response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result", new[] { "Partial data", "Rate limit applied" });
+    /// var _response = ServiceResponse.CreateWarning(HttpStatusCode.PartialContent, "Partial result", new[] { "Partial data", "Rate limit applied" });
     /// ]]>
     /// </example>
     public new static ServiceResponse<T> CreateWarning(HttpStatusCode responseCode, string errorMessage, string[]? warningMessgaes) 


### PR DESCRIPTION
Necessary modifications were made to correct errors in the declaration of local variables in the usage examples of XML documentation comments. The first instruction in all classes, interfaces, enumerations, and structures has also been fixed as the object's namespace.

- Modified classes containing usings so that the first instruction is always the namespace.
- Once classes containing examples are modified in XML documentation comments, and variables are declared, they must follow SOLTEC programming rules.
